### PR TITLE
fix: multiple issues

### DIFF
--- a/src/FsYaml/Representation.fs
+++ b/src/FsYaml/Representation.fs
@@ -52,7 +52,7 @@ let rec yamlDotNetToIntermediate (node: YamlNode) =
         let value = yamlDotNetToIntermediate value
         (key, value)
       )
-      |> Map.ofSeq
+      |> Seq.toList
     Mapping(mapping, position)
   | notSupported -> raise (FsYamlException.WithPosition(position, Resources.getString "notSupportedNode", Type.print (notSupported.GetType())))
     
@@ -76,7 +76,7 @@ let rec intermediateToYamlDotNet (yaml: YamlObject) =
   | Mapping (mapping, _) ->
     let children =
       mapping
-      |> Seq.map (fun (KeyValue(k, v)) ->
+      |> List.map (fun (k, v) ->
         let key = intermediateToYamlDotNet k
         let value = intermediateToYamlDotNet v
         KeyValuePair(key, value)

--- a/src/FsYaml/TypeDefinitions.fs
+++ b/src/FsYaml/TypeDefinitions.fs
@@ -40,14 +40,14 @@ module internal Detail =
   let decimalDef = { Accept = (=)typeof<decimal>; Construct = constructFromScalar decimal; Represent = representAsPlain string }
   let datetimeDef = {
     Accept = (=)typeof<DateTime>
-    Construct = constructFromScalar (fun x -> DateTime.Parse(x))
+    Construct = constructFromScalar (fun x -> DateTime.Parse(x, System.Globalization.CultureInfo.InvariantCulture))
     Represent = representAsNonPlain (fun x ->
       let d = unbox<DateTime> x
       d.ToString("yyyy-MM-dd HH:mm:ss.fff"))
   }
   let timespanDef = {
     Accept = (=)typeof<TimeSpan>
-    Construct = constructFromScalar (fun x -> TimeSpan.Parse(x))
+    Construct = constructFromScalar (fun x -> TimeSpan.Parse(x, System.Globalization.CultureInfo.InvariantCulture))
     Represent = representAsNonPlain (fun x ->
       let t = unbox<TimeSpan> x
       t.ToString(@"hh\:mm\:ss\.fff")
@@ -119,7 +119,7 @@ module internal Detail =
           then None  // Omit if it's the default value of the field
           else Some (name, value)
         )
-        |> Map.ofSeq
+        |> Seq.toList
       Mapping (values, None)
 
   let recordDef = {
@@ -180,7 +180,7 @@ module internal Detail =
         let keyType, valueType = let ts = t.GetGenericArguments() in (ts.[0], ts.[1])
         let values =
           mapping
-          |> Seq.map (fun (KeyValue(keyYaml, valueYaml)) ->
+          |> Seq.map (fun (keyYaml, valueYaml) ->
             let key = construct' keyType keyYaml
             let value = construct' valueType valueYaml
             (key, value)
@@ -199,7 +199,7 @@ module internal Detail =
           let value = represent valueType value
           (key, value)
         )
-        |> Map.ofSeq
+        |> Seq.toList
       Mapping (values, None)
   }
 
@@ -240,7 +240,7 @@ module internal Detail =
           None
       | _ -> None
 
-    let tryNamedFieldCase construct' (union: UnionCaseInfo) (mapping: Map<YamlObject, YamlObject>) =
+    let tryNamedFieldCase construct' (union: UnionCaseInfo) (mapping: (YamlObject * YamlObject) list) =
       let fields = union.GetFields()
       let yamls = fields |> Array.choose (fun field -> Mapping.tryFind field.Name mapping)
         
@@ -299,7 +299,7 @@ module internal Detail =
       let fields = union.GetFields()
       let valueType = fields.[0].PropertyType
       let value = represent valueType value
-      Mapping (Map.ofList [caseName union, value ], None)
+      Mapping ([ caseName union, value ], None)
 
     let manyFields represent (union: UnionCaseInfo) (values: obj[]) =
       let fields = union.GetFields()
@@ -309,7 +309,7 @@ module internal Detail =
           |> Seq.map (fun (field, value) -> represent field.PropertyType value)
           |> Seq.toList
         Sequence (xs, None)
-      Mapping (Map.ofList [ caseName union, fieldValues ], None)
+      Mapping ([ caseName union, fieldValues ], None)
 
     let isNamedFieldCase (union: UnionCaseInfo) =
       let fields = union.GetFields()
@@ -327,10 +327,10 @@ module internal Detail =
           let value = represent field.PropertyType value
           (name, value)
         )
-        |> Map.ofSeq
+        |> Seq.toList
       let name = caseName union
       let fieldMapping = Mapping (values, None)
-      Mapping (Map.ofList [ name, fieldMapping ], None)
+      Mapping ([ name, fieldMapping ], None)
 
     let represent (represent: RecursiveRepresenter) (t: Type) (obj: obj) =
       let union, values = FSharpValue.GetUnionFields(obj, t)
@@ -355,14 +355,16 @@ module internal Detail =
     Accept = fun t -> FSharpType.IsUnion(t) && isGenericTypeDef typedefof<Option<_>> t
     Construct = fun construct' t yaml ->
       let noneCase, someCase = let xs = FSharpType.GetUnionCases(t) in (xs.[0], xs.[1])
+      let parameterType = t.GetGenericArguments().[0]
       match yaml with
-      | Null _ -> (UnionConstructor.makeUnion noneCase [])
+      | Null _ -> UnionConstructor.makeUnion noneCase []
+      | Scalar (s, _) when Scalar.value s = noneCase.Name ->
+        UnionConstructor.makeUnion noneCase []
+      | Mapping (mapping, _) when Mapping.tryFind someCase.Name mapping |> Option.isSome ->
+        unionDef.Construct construct' t yaml
       | _ ->
-        try
-          let parameterType = t.GetGenericArguments().[0]
-          let value = construct' parameterType yaml
-          UnionConstructor.makeUnion someCase [ value ]
-        with _ ->  unionDef.Construct construct' t yaml
+        let value = construct' parameterType yaml
+        UnionConstructor.makeUnion someCase [ value ]
     Represent = fun represent t obj ->
       match obj with
       | null -> Null None

--- a/src/FsYaml/Types.fs
+++ b/src/FsYaml/Types.fs
@@ -28,8 +28,8 @@ module RepresentationTypes =
     | Scalar of Scalar * Position option
     /// Sequence node
     | Sequence of YamlObject list * Position option
-    /// Mapping node
-    | Mapping of Map<YamlObject, YamlObject> * Position option
+    /// Mapping node (key-value pairs in document order)
+    | Mapping of (YamlObject * YamlObject) list * Position option
     /// Null value that specializes in Scalar
     | Null of Position option
 
@@ -51,17 +51,20 @@ module RepresentationTypes =
   /// It is a module that operates Mapping.
   [<CompilationRepresentation(CompilationRepresentationFlags.ModuleSuffix)>]
   module Mapping =
-    let private pickF name = (fun k v ->
-      match k with
-      | Scalar (k, _) -> if Scalar.value k = name then Some v else None
-      | _ -> None)
     /// Search for elements in Mapping. Returns None if the element does not exist.
-    let tryFind key (mapping: Map<YamlObject, YamlObject>) = Map.tryPick (pickF key) mapping
+    let tryFind key (mapping: (YamlObject * YamlObject) list) =
+      mapping |> List.tryPick (fun (k, v) ->
+        match k with
+        | Scalar (s, _) when Scalar.value s = key -> Some v
+        | _ -> None)
     /// <summary>
     /// Search for elements in Mapping.
     /// </summary>
     /// <exception cref="System.Collections.Generic.KeyNotFoundException">If the key does not exist</exception>
-    let find key (mapping: Map<YamlObject, YamlObject>) = Map.pick (pickF key) mapping
+    let find key mapping =
+      match tryFind key mapping with
+      | Some v -> v
+      | None -> raise (System.Collections.Generic.KeyNotFoundException($"The key '{key}' was not found."))
 
 /// Provides a type of Native layer for Yaml.
 module NativeTypes =

--- a/src/FsYaml/Utility.fs
+++ b/src/FsYaml/Utility.fs
@@ -110,11 +110,11 @@ module Union =
   let printCase (x: UnionCaseInfo) = $"%s{Type.print x.DeclaringType}.%s{x.Name}"
 
 module Seq =
-  let tryZip xs ys =
-    if Seq.length xs <> Seq.length ys then
-      None
-    else
-      Some (Seq.zip xs ys)
+  let tryZip (xs: 'a seq) (ys: 'b seq) =
+    let xs = Seq.toArray xs
+    let ys = Seq.toArray ys
+    if xs.Length <> ys.Length then None
+    else Some (Seq.zip xs ys)
 
 module Option =
   let filter f = Option.bind (fun x -> if f x then Some x else None)

--- a/src/FsYaml/Yaml.fs
+++ b/src/FsYaml/Yaml.fs
@@ -48,7 +48,7 @@ let tryLoad<'a> yamlStr =
   try
     Some (load<'a> yamlStr)
   with
-    _ -> None
+    :? FsYamlException -> None
 
 /// <summary>
 /// Loads a Yaml string as an <c>&#39;a</ c> object based on the specified type information and the default type information. Returns None if loading fails.
@@ -60,7 +60,7 @@ let tryLoadWith<'a> customDefinitions yamlStr =
   try
     Some (loadWith<'a> customDefinitions yamlStr)
   with
-    _ -> None
+    :? FsYamlException -> None
 
 /// <summary>
 /// Load the Yaml string as an object of <c>typ</ c>.
@@ -88,7 +88,7 @@ let tryLoadUntyped typ yamlStr =
   try
     Some (loadUntyped typ yamlStr)
   with
-    _ -> None
+    :? FsYamlException -> None
 
 /// <summary>
 /// Loads a Yaml string as an <c>typ</c> object based on the specified type information and the default type information. Returns None if loading fails.
@@ -101,7 +101,7 @@ let tryLoadWithUntyped typ customDefinitions yamlStr =
   try
     Some (loadWithUntyped typ customDefinitions yamlStr)
   with
-    _ -> None
+    :? FsYamlException -> None
 
 /// <summary>
 /// Dump the object to a Yaml string.

--- a/tests/FsYaml.Tests/DumpingTest.fs
+++ b/tests/FsYaml.Tests/DumpingTest.fs
@@ -16,7 +16,7 @@ module Helper =
   let plain x = scalar (Plain x)
   let nonPlain x = scalar (NonPlain x)
   let sequence x = Sequence (x, None)
-  let mapping x = Mapping (Map.ofSeq x, None)
+  let mapping x = Mapping (Seq.toList x, None)
   let null' = Null None
 
 open Types

--- a/tests/FsYaml.Tests/FsYaml.Tests.fsproj
+++ b/tests/FsYaml.Tests/FsYaml.Tests.fsproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="IssuesTest.fs" />
     <Compile Include="UtilityTest.fs" />
     <Compile Include="TypesTest.fs" />
     <Compile Include="LoadingTest.fs" />

--- a/tests/FsYaml.Tests/IssuesTest.fs
+++ b/tests/FsYaml.Tests/IssuesTest.fs
@@ -1,0 +1,40 @@
+module IssuesTest
+
+open System
+open Expecto
+open FsYaml
+open FsYaml.NativeTypes
+
+// Record where declaration order differs from alphabetical order
+type OutOfAlphaOrderRecord = { Zebra: int; Alpaca: string; Mango: bool }
+
+[<Tests>]
+let fieldOrderTests =
+  testList "Field order" [
+    testCase "dump preserves record field declaration order not alphabetical" <| fun () ->
+      let yaml = Yaml.dump { Zebra = 1; Alpaca = "a"; Mango = true }
+      let fieldNames =
+        yaml.Split('\n')
+        |> Array.filter (fun l -> l.Contains(':') && l.Trim() <> "")
+        |> Array.map (fun l -> l.Trim().Split(':').[0])
+      Expect.equal (Array.toList fieldNames) [ "Zebra"; "Alpaca"; "Mango" ]
+        "fields should appear in declaration order (Zebra, Alpaca, Mango), not alphabetical (Alpaca, Mango, Zebra)"
+  ]
+
+[<Tests>]
+let tryLoadTests =
+  testList "tryLoad" [
+    testCase "tryLoad does not swallow non-FsYamlException" <| fun () ->
+      // Exceptions thrown in Accept are NOT wrapped by Native.fs (they occur outside its try block).
+      // Before the fix, tryLoad's bare `_ -> None` swallowed them silently.
+      let buggyDef = {
+        Accept = fun t ->
+          if t = typeof<int> then raise (InvalidOperationException("deliberate bug in Accept"))
+          else false
+        Construct = fun _ _ _ -> box 0
+        Represent = fun _ _ _ -> FsYaml.RepresentationTypes.Null None
+      }
+      Expect.throwsT<InvalidOperationException>
+        (fun () -> Yaml.tryLoadWith<int> [ buggyDef ] "1" |> ignore)
+        "non-FsYamlException should propagate out of tryLoad, not be silently swallowed"
+  ]

--- a/tests/FsYaml.Tests/LoadingTest.fs
+++ b/tests/FsYaml.Tests/LoadingTest.fs
@@ -11,7 +11,7 @@ let rec clearPosition = function
   | Scalar (v, _) -> Scalar (v, None)
   | Sequence (v, _) -> Sequence (List.map clearPosition v, None)
   | Mapping (v, _) ->
-    let mapping = v |> Seq.map (fun (KeyValue(k, v)) -> clearPosition k, clearPosition v) |> Map.ofSeq
+    let mapping = v |> List.map (fun (k, v) -> clearPosition k, clearPosition v)
     Mapping (mapping, None)
   | Null _ -> Null None
 
@@ -81,15 +81,15 @@ let representationTests =
     ]
     testList "can parse Mapping" [
       let expected =
-        Mapping (Map.ofList [ Scalar (Plain "abc", None), Scalar (Plain "def", None)
-                               ; Scalar (Plain "ghi", None), Sequence ([ Scalar (Plain "jkf", None) ], None) ], None)
+        Mapping ([ Scalar (Plain "abc", None), Scalar (Plain "def", None)
+                   Scalar (Plain "ghi", None), Sequence ([ Scalar (Plain "jkf", None) ], None) ], None)
       yield testCase "flow style" <| fun () ->
         Expect.equal (parse "{ abc: def, ghi: [ jkf ] }") expected ""
       yield testCase "block style" <| fun () ->
         Expect.equal (parse "abc: def\nghi:\n     - jkf") expected ""
     ]
     testList "can parse Null" [
-      let expected = Mapping (Map.ofList [ Scalar (Plain "abc", None), Null None ], None)
+      let expected = Mapping ([ Scalar (Plain "abc", None), Null None ], None)
       for input in [ "abc: "; "abc: null"; "abc: ~" ] do
         yield testCase input <| fun () ->
           Expect.equal (parse input) expected ""

--- a/tests/FsYaml.Tests/TypesTest.fs
+++ b/tests/FsYaml.Tests/TypesTest.fs
@@ -8,6 +8,6 @@ open FsYaml.RepresentationTypes
 let tests =
   testList "Types" [
     testCase "Mapping.find throws KeyNotFoundException when key not found" <| fun () ->
-      let m = Map.ofList [ Scalar (Plain "1", None), Scalar (Plain "2", None) ]
+      let m = [ Scalar (Plain "1", None), Scalar (Plain "2", None) ]
       Expect.throwsT<KeyNotFoundException> (fun () -> Mapping.find "3" m |> ignore) ""
   ]


### PR DESCRIPTION
  - [x] Field order: Mapping backing type changed from Map to (YamlObject * YamlObject) list — record fields now dump in declaration order           
  - [x] tryLoad: narrow catch from _ to :? FsYamlException to stop swallowing unrelated exceptions                                                   
  - [x] optionDef: replace exception-as-control-flow with explicit pattern matching                                                                  
  - [x] DateTime/TimeSpan: parse with InvariantCulture                                                                                               
  - [x] Seq.tryZip: single-pass via toArray instead of Seq.length then re-enumerate                                                                  
  - [x] Tests: migrate Persimmon → Expecto (tests were compiling but never running); target net10.0; fix CI pipeline